### PR TITLE
Remove deprecated things

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,6 @@ jobs:
     - name: Starting up Postgres & Redis
       run: docker-compose up -d
     - name: Running integration tests
-      run: sbt it:test
+      run: sbt IntegrationTest/test
     - name: Shutting down Postgres & Redis
       run: docker-compose down

--- a/build.sbt
+++ b/build.sbt
@@ -5,9 +5,10 @@ ThisBuild / scalaVersion := "2.13.10"
 ThisBuild / version      := "0.1.0"
 
 ThisBuild / evictionErrorLevel := Level.Warn
-ThisBuild / scalafixDependencies ++= Libs.scalafix
-ThisBuild / semanticdbEnabled  := true
-ThisBuild / semanticdbVersion  := scalafixSemanticdb.revision
+ThisBuild / libraryDependencySchemes ++= Schemes.all
+
+ThisBuild / semanticdbEnabled := true
+ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 
 lazy val commons = Seq(
   fork      := true,

--- a/modules/core/src/main/scala/dev/meetree/shop/module/HttpApi.scala
+++ b/modules/core/src/main/scala/dev/meetree/shop/module/HttpApi.scala
@@ -70,7 +70,7 @@ sealed abstract class HttpApi[F[_]: Async] private (
   private val middleware: HttpRoutes[F] => HttpRoutes[F] =
     chain(
       AutoSlash(_),
-      CORS(_),
+      CORS.policy(_),
       Timeout(60.seconds)(_)
     )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,9 +27,6 @@ object Dependencies {
     // Testing
     val weaver = "0.8.4"
 
-    // Scalafix
-    val `organize-imports` = "0.6.0"
-
     // Compiler plugins
     val `better-monadic-for` = "0.3.1"
     val `kind-projector`     = "0.13.3"
@@ -101,9 +98,6 @@ object Dependencies {
     val `weaver-discipline`  = weaver("discipline")
     val `weaver-cats`        = weaver("cats")
 
-    // Scalafix
-    val `organize-imports` = "com.github.liancheng" %% "organize-imports" % V.`organize-imports`
-
     val core = Seq(
       `cats-core`,
       `cats-effect`,
@@ -148,8 +142,6 @@ object Dependencies {
       `log4cats-noop`
     )
       .map(_ % Test)
-
-    val scalafix = Seq(`organize-imports`)
   }
 
   object CompilerPlugins {
@@ -161,5 +153,11 @@ object Dependencies {
       .map(compilerPlugin)
 
     val test = core
+  }
+
+  object Schemes {
+    val `circe-core` = Libs.`circe-core` withRevision VersionScheme.Always
+
+    val all = Seq(`circe-core`)
   }
 }


### PR DESCRIPTION
- Remove deprecated sbt syntax
- Remove deprecated CORS config
- Remove built-in OrganizeImports rule in scalafix
- Ignore circe version scheme